### PR TITLE
Remove obsolete macro AC_HEADER_STDC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,6 @@ AC_PROG_LN_S
 AC_PROG_INSTALL
 
 # Configuration.
-AC_HEADER_STDC
 AC_CHECK_HEADERS(sys/time.h)
 AC_CHECK_FUNCS(strstr getopt getsubopt gettimeofday)
 


### PR DESCRIPTION
@troglobit while trying to port uftpd to meson build system* I was trying to find how to port  AC_HEADER_STDC  check to meson. I found the following commit in XORG which is 8 years old:

https://gitlab.freedesktop.org/xorg/test/rendercheck/commit/73623549b4eae25f0884f11875d95b3b8fa948cf

Glib also removed this macro:

https://github.com/GNOME/glib/blob/57a1d793610433a550ee9165be20f06a0473f250/NEWS#L4255

I think this check can be removed here too.

* not sure it's going to be accepted by you, but I am doing this as a way to learn meson on a real project which isn't too big.
 