### PR TITLE
Add option for override address passed to the client in passive mode

### DIFF
--- a/man/uftpd.8
+++ b/man/uftpd.8
@@ -72,6 +72,7 @@ option, separate multiple options with comma:
 .It Ar ftp=PORT
 .It Ar tftp=PORT
 .It Ar writable
+.It Ar pasv_addr=ADDR
 .El
 .Pp
 Override Internet ports otherwise derived from
@@ -87,6 +88,11 @@ want this, but it is recommended to instead rely on a writable
 sub-directory, like
 .Ar upload/ ,
 or similar.
+.Pp
+An address passed to the client in passive mode can be overrided with the
+.Ar pasv_addr
+option (real data socket address remains unchanged). This may be useful for
+passing through some types of NAT.
 .It Fl s
 Use syslog, even if running in foreground, default when running in the
 background

--- a/src/ftpcmd.c
+++ b/src/ftpcmd.c
@@ -971,7 +971,10 @@ static void handle_PASV(ctrl_t *ctrl, char *arg)
 		return;
 
 	/* Convert server IP address and port to comma separated list */
-	msg = strdup(ctrl->serveraddr);
+	if (pasv_addr)
+		msg = strdup(pasv_addr);
+	else
+		msg = strdup(ctrl->serveraddr);
 	if (!msg) {
 		send_msg(ctrl->sd, "426 Internal server error.\r\n");
 		exit(1);

--- a/src/uftpd.c
+++ b/src/uftpd.c
@@ -25,6 +25,7 @@ int   background  = 1;
 int   do_syslog   = 1;
 int   do_ftp      = FTP_DEFAULT_PORT;
 int   do_tftp     = TFTP_DEFAULT_PORT;
+char *pasv_addr   = NULL;
 int   do_insecure = 0;
 pid_t tftp_pid    = 0;
 struct passwd *pw = NULL;
@@ -62,6 +63,7 @@ static int usage(int code)
 		       "                      ftp=PORT\n"
 		       "                      tftp=PORT\n"
 		       "                      writable\n"
+		       "                      pasv_addr=ADDR\n"
 		       "  -s         Use syslog, even if running in foreground, default w/o -n\n");
 
 	printf("  -v         Show program version\n\n");
@@ -270,15 +272,18 @@ int main(int argc, char **argv)
 		FTP_OPT = 0,
 		TFTP_OPT,
 		SEC_OPT,
+		PASV_OPT
 	};
 	char *subopts;
 	char *const token[] = {
 		[FTP_OPT]  = "ftp",
 		[TFTP_OPT] = "tftp",
 		[SEC_OPT]  = "writable",
+		[PASV_OPT] = "pasv_addr",
 		NULL
 	};
 	uev_ctx_t ctx;
+	struct in_addr in_pasv_addr;
 
 	prognm = progname(argv[0]);
 	while ((c = getopt(argc, argv, "hl:no:sv")) != EOF) {
@@ -318,7 +323,17 @@ int main(int argc, char **argv)
 					}
 					do_tftp = atoi(value);
 					break;
-
+				case PASV_OPT:
+					if (!value) {
+						fprintf(stderr, "Missing PASV address argument to -o pasv_addr=ADDR");
+						return usage(1);
+					}
+					if (!inet_aton(value,&in_pasv_addr)) {
+						fprintf(stderr, "Value specified to pasv_addr is not a valid IPv4 address");
+						return usage(1);
+					}
+					pasv_addr = strdup(value);
+					break;
 				case SEC_OPT:
 					do_insecure = 1;
 					break;

--- a/src/uftpd.h
+++ b/src/uftpd.h
@@ -97,6 +97,7 @@ extern int   loglevel;
 extern int   do_syslog;         /* Bool: False at daemon start      */
 extern int   do_ftp;            /* Port: FTP port, or disabled      */
 extern int   do_tftp;           /* Port: TFTP port, or disabled     */
+extern char *pasv_addr;	/* Address passed to client in pasv mode */
 extern int   do_insecure;	/* Bool: Allow writable root or not */
 extern struct passwd *pw;       /* FTP user's passwd entry          */
 


### PR DESCRIPTION
This option may be helpful for passing through some NATs. Developed it to make server reachable from QEMU guests with SLIRP (a.k.a "user") network backend: it translates virtual network gateway address on guest side to 127.0.0.1 on host side and vice versa, so server must pass translated address in PASV response to make data connection possible.